### PR TITLE
ADD : benchmark

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="DistributedLock" Version="1.4.0" />
+    <PackageReference Include="KeySmith" Version="0.2.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="RedLock.net" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/Benchmarks/MultipleThreadsScenario.cs
+++ b/Benchmarks/MultipleThreadsScenario.cs
@@ -1,0 +1,108 @@
+﻿using BenchmarkDotNet.Attributes;
+using KeySmith;
+using Medallion.Threading.Sql;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    public class MultipleThreadsScenario
+    {
+        /// <summary>
+        /// Change this to change task time
+        /// </summary>
+        private static readonly int _taskTime = 1;
+
+        /// <summary>
+        /// Change this to change how many thread are asking for the lock at the same time
+        /// </summary>
+        [Params(1, 2, 5, 10, 20, 50, 100)]
+        public int Count { get; set; }
+
+        //Native
+        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+
+        //KeySmith
+        private readonly ILockService _lockService;
+        private readonly Key _key;
+
+        //distributedLock
+        private readonly SqlDistributedLock _sqlDistributedLock;
+
+        //RedLockNET
+        //private readonly RedLockFactory _redLockFactory;
+
+        public MultipleThreadsScenario()
+        {
+            var services = new ServiceCollection();
+
+            //KeySmith
+            services.AddKeySmith("localhost:6379");
+
+            var provider = services.BuildServiceProvider();
+
+            _lockService = provider.GetRequiredService<ILockService>();
+            _key = new Key(Guid.NewGuid().ToString(), "mylock", TimeSpan.FromMilliseconds(500));
+
+            //TODO fix connectionstring
+            _sqlDistributedLock = new SqlDistributedLock("lockName", "Data Source=localhost;Initial Catalog=WS_EXCHANGE_RATE;user=ilucca;password=ilucca;MultipleActiveResultSets=True");
+
+            //RedLock
+            //_redLockFactory = RedLockFactory.Create(new List<RedLockMultiplexer> { provider.GetRequiredService<ConnectionMultiplexer>() });
+        }
+
+        private static Task Times(int count, Func<Task> task) => Task.WhenAll(Enumerable.Range(0, count).Select(i => task()));
+
+        [Benchmark]
+        public Task Unsynchronized() => Times(Count, () => SharedTask(CancellationToken.None));
+
+        [Benchmark]
+        public Task Native() => Times(Count, NativeTask);
+        async Task NativeTask()
+        {
+            await _semaphore.WaitAsync();
+            try
+            {
+                await SharedTask(CancellationToken.None);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+
+        [Benchmark]
+        public Task KeySmith() => Times(Count, KeySmithTask);
+        public Task KeySmithTask() => _lockService.LockAsync(_key, SharedTask, CancellationToken.None);
+
+        [Benchmark]
+        public Task SqlDistributedLock() => Times(Count, SqlDistributedLockTask);
+        public async Task SqlDistributedLockTask()
+        {
+            using (var sqlLock = await _sqlDistributedLock.AcquireAsync())
+            {
+                await SharedTask(CancellationToken.None);
+            }
+        }
+
+        //[Benchmark]
+        //public Task RedLock() => Times(_count, RedLockTask);
+        //public async Task RedLockTask()
+        //{
+        //    using (var locker = await _redLockFactory.CreateLockAsync("resource", TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(10)))
+        //    {
+        //        if (!locker.IsAcquired)
+        //        {
+        //            throw new InvalidOperationException("Not testing properly");
+        //        }
+        //        await SharedTask(CancellationToken.None);
+        //    }
+        //}
+
+        private static Task SharedTask(CancellationToken token) => Task.Delay(_taskTime);
+    }
+}

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -1,0 +1,15 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+
+namespace Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var config = DefaultConfig.Instance;
+            config = config.With(ConfigOptions.DisableOptimizationsValidator);
+            var summary = BenchmarkRunner.Run<MultipleThreadsScenario>(config);
+        }
+    }
+}

--- a/KeySmith.sln
+++ b/KeySmith.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29319.158
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeySmith", "KeySmith\KeySmith.csproj", "{140CCD48-8461-463F-9BA9-001D79AA5E05}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KeySmith", "KeySmith\KeySmith.csproj", "{140CCD48-8461-463F-9BA9-001D79AA5E05}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeySmith.Tests", "KeySmith.Tests\KeySmith.Tests.csproj", "{C17010DE-6908-4AFE-B222-3792F03BEA29}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KeySmith.Tests", "KeySmith.Tests\KeySmith.Tests.csproj", "{C17010DE-6908-4AFE-B222-3792F03BEA29}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "Benchmarks\Benchmarks.csproj", "{ACF895AD-5397-4B73-83F3-05F07BEDB04A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{C17010DE-6908-4AFE-B222-3792F03BEA29}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C17010DE-6908-4AFE-B222-3792F03BEA29}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C17010DE-6908-4AFE-B222-3792F03BEA29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACF895AD-5397-4B73-83F3-05F07BEDB04A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACF895AD-5397-4B73-83F3-05F07BEDB04A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACF895AD-5397-4B73-83F3-05F07BEDB04A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACF895AD-5397-4B73-83F3-05F07BEDB04A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.805 (1809/October2018Update/Redstone5)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.100-preview1-014459
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT DEBUG
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT


```
|             Method | Count |      Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |------ |----------:|----------:|----------:|------:|------:|------:|----------:|
|             **Native** |     **1** |  **15.59 ms** | **0.0214 ms** | **0.0200 ms** |     **-** |     **-** |     **-** |     **792 B** |
|           KeySmith |     1 |  15.57 ms | 0.0374 ms | 0.0349 ms |     - |     - |     - |    2824 B |
| SqlDistributedLock |     1 |  15.57 ms | 0.0254 ms | 0.0237 ms |     - |     - |     - |    5240 B |
|             **Native** |     **2** |  **31.19 ms** | **0.0458 ms** | **0.0429 ms** |     **-** |     **-** |     **-** |    **1008 B** |
|           KeySmith |     2 |  31.15 ms | 0.0665 ms | 0.0622 ms |     - |     - |     - |    5832 B |
| SqlDistributedLock |     2 |  31.14 ms | 0.0621 ms | 0.0581 ms |     - |     - |     - |    9984 B |
|             **Native** |     **5** |  **77.69 ms** | **0.3507 ms** | **0.3280 ms** |     **-** |     **-** |     **-** |    **1744 B** |
|           KeySmith |     5 |  77.61 ms | 0.4508 ms | 0.4217 ms |     - |     - |     - |   14896 B |
| SqlDistributedLock |     5 |  77.61 ms | 0.3916 ms | 0.3663 ms |     - |     - |     - |   24304 B |
|             **Native** |    **10** | **155.47 ms** | **0.5491 ms** | **0.5137 ms** |     **-** |     **-** |     **-** |    **2976 B** |
|           KeySmith |    10 | 155.40 ms | 0.5420 ms | 0.5070 ms |     - |     - |     - |   29920 B |
| SqlDistributedLock |    10 | 155.34 ms | 0.6577 ms | 0.6152 ms |     - |     - |     - |   48176 B |
|             **Native** |    **20** | **311.06 ms** | **0.8673 ms** | **0.8113 ms** |     **-** |     **-** |     **-** |    **5416 B** |
|           KeySmith |    20 | 308.85 ms | 2.5631 ms | 2.3976 ms |     - |     - |     - |   59920 B |
| SqlDistributedLock |    20 | 309.08 ms | 2.1504 ms | 2.0115 ms |     - |     - |     - |   95896 B |
|             **Native** |    **50** | **778.36 ms** | **2.1801 ms** | **2.0393 ms** |     **-** |     **-** |     **-** |   **12432 B** |
|           KeySmith |    50 | 777.70 ms | 2.1235 ms | 1.9863 ms |     - |     - |     - |  149360 B |
| SqlDistributedLock |    50 | 777.20 ms | 2.0864 ms | 1.9516 ms |     - |     - |     - |  238752 B |
